### PR TITLE
Style budget entry row like summary row

### DIFF
--- a/src/budget/BudgetEntryRow.stories.tsx
+++ b/src/budget/BudgetEntryRow.stories.tsx
@@ -59,11 +59,21 @@ export const ListPreview: Story = {
         onClick={() => {}}
       />
       <BudgetEntryRow
-        entry={{ id: "2", name: "Internet", amount: 500, frequency: "biMonthly" }}
+        entry={{
+          id: "2",
+          name: "Internet",
+          amount: 500,
+          frequency: "biMonthly",
+        }}
         onClick={() => {}}
       />
       <BudgetEntryRow
-        entry={{ id: "3", name: "Groceries", amount: null, frequency: "monthly" }}
+        entry={{
+          id: "3",
+          name: "Groceries",
+          amount: null,
+          frequency: "monthly",
+        }}
         onClick={() => {}}
       />
     </div>

--- a/src/budget/BudgetEntryRow.stories.tsx
+++ b/src/budget/BudgetEntryRow.stories.tsx
@@ -46,3 +46,26 @@ export const NoAmount: Story = {
     onClick: () => {},
   },
 };
+
+export const ListPreview: Story = {
+  args: {
+    entry: { id: "x", name: "", amount: 0, frequency: "monthly" },
+    onClick: () => {},
+  },
+  render: () => (
+    <div className="flex flex-col gap-1">
+      <BudgetEntryRow
+        entry={{ id: "1", name: "Salary", amount: 12000, frequency: "monthly" }}
+        onClick={() => {}}
+      />
+      <BudgetEntryRow
+        entry={{ id: "2", name: "Internet", amount: 500, frequency: "biMonthly" }}
+        onClick={() => {}}
+      />
+      <BudgetEntryRow
+        entry={{ id: "3", name: "Groceries", amount: null, frequency: "monthly" }}
+        onClick={() => {}}
+      />
+    </div>
+  ),
+};

--- a/src/budget/BudgetEntryRow.tsx
+++ b/src/budget/BudgetEntryRow.tsx
@@ -14,7 +14,9 @@ export function BudgetEntryRow({ entry, onClick }: BudgetEntryRowProps) {
     >
       <div className="flex items-baseline justify-between w-full gap-3">
         {entry.name && (
-          <span className="text-muted-foreground text-sm truncate">{entry.name}</span>
+          <span className="text-muted-foreground text-sm truncate">
+            {entry.name}
+          </span>
         )}
         {entry.amount && (
           <span className="font-medium text-gray-900">

--- a/src/budget/BudgetEntryRow.tsx
+++ b/src/budget/BudgetEntryRow.tsx
@@ -20,12 +20,12 @@ export function BudgetEntryRow({ entry, onClick }: BudgetEntryRowProps) {
         )}
         {entry.amount && (
           <span className="text-sm text-gray-900">
-            ₪{entry.amount.toLocaleString()}
             {entry.frequency === "biMonthly" && (
-              <span className="text-xs text-muted-foreground ml-2">
+              <span className="text-xs text-muted-foreground mr-2">
                 (₪{normalizeAmount(entry).toLocaleString()}/month)
               </span>
             )}
+            ₪{entry.amount.toLocaleString()}
           </span>
         )}
       </div>

--- a/src/budget/BudgetEntryRow.tsx
+++ b/src/budget/BudgetEntryRow.tsx
@@ -9,7 +9,7 @@ interface BudgetEntryRowProps {
 export function BudgetEntryRow({ entry, onClick }: BudgetEntryRowProps) {
   return (
     <div
-      className="flex items-baseline justify-between rounded-md px-3 py-2 cursor-pointer hover:opacity-80 transition-opacity hover:bg-gray-50 active:bg-gray-100"
+      className="flex items-baseline justify-between rounded-md px-3 py-2 cursor-pointer bg-slate-50 hover:opacity-80 transition-opacity"
       onClick={onClick}
     >
       <div className="flex items-baseline justify-between w-full gap-3">

--- a/src/budget/BudgetEntryRow.tsx
+++ b/src/budget/BudgetEntryRow.tsx
@@ -9,7 +9,7 @@ interface BudgetEntryRowProps {
 export function BudgetEntryRow({ entry, onClick }: BudgetEntryRowProps) {
   return (
     <div
-      className="flex items-baseline justify-between rounded-md px-3 py-2 cursor-pointer bg-slate-50 hover:opacity-80 transition-opacity"
+      className="flex items-baseline justify-between rounded-md px-3 py-2 cursor-pointer bg-slate-50 hover:opacity-80 active:bg-slate-100 transition-colors transition-opacity"
       onClick={onClick}
     >
       <div className="flex items-baseline justify-between w-full gap-3">

--- a/src/budget/BudgetEntryRow.tsx
+++ b/src/budget/BudgetEntryRow.tsx
@@ -9,16 +9,18 @@ interface BudgetEntryRowProps {
 export function BudgetEntryRow({ entry, onClick }: BudgetEntryRowProps) {
   return (
     <div
-      className="flex justify-between px-2 py-2 transition-colors hover:bg-gray-50 active:bg-gray-100 cursor-pointer"
+      className="flex items-baseline justify-between rounded-md px-3 py-2 cursor-pointer hover:opacity-80 transition-opacity hover:bg-gray-50 active:bg-gray-100"
       onClick={onClick}
     >
-      <div className="flex justify-between text-gray-900 truncate w-full">
-        {entry.name && <span className="mr-3">{entry.name}</span>}
+      <div className="flex items-baseline justify-between w-full gap-3">
+        {entry.name && (
+          <span className="text-muted-foreground text-sm truncate">{entry.name}</span>
+        )}
         {entry.amount && (
-          <span>
+          <span className="font-medium text-gray-900">
             ₪{entry.amount.toLocaleString()}
             {entry.frequency === "biMonthly" && (
-              <span className="text-sm text-gray-600 ml-1">
+              <span className="text-xs text-muted-foreground ml-2">
                 (₪{normalizeAmount(entry).toLocaleString()}/month)
               </span>
             )}

--- a/src/budget/BudgetEntryRow.tsx
+++ b/src/budget/BudgetEntryRow.tsx
@@ -19,7 +19,7 @@ export function BudgetEntryRow({ entry, onClick }: BudgetEntryRowProps) {
           </span>
         )}
         {entry.amount && (
-          <span className="font-medium text-gray-900">
+          <span className="text-sm text-gray-900">
             ₪{entry.amount.toLocaleString()}
             {entry.frequency === "biMonthly" && (
               <span className="text-xs text-muted-foreground ml-2">

--- a/src/budget/BudgetSection.tsx
+++ b/src/budget/BudgetSection.tsx
@@ -58,7 +58,7 @@ export function BudgetSection({
         {entries.length === 0 ? (
           <p className="text-sm text-center text-gray-400">No entries yet</p>
         ) : (
-          <div className="flex flex-col">
+          <div className="flex flex-col gap-px">
             {entries.map((entry, index) => (
               <BudgetEntryRow
                 key={entry.id}

--- a/src/budget/SummaryRow.tsx
+++ b/src/budget/SummaryRow.tsx
@@ -34,9 +34,7 @@ export function SummaryRow({
       >
         {label}
       </span>
-      <span
-        className={cn("font-medium", valueColor, isBold && "font-semibold")}
-      >
+      <span className={cn("text-sm", valueColor, isBold && "font-semibold")}>
         {value}
       </span>
     </div>


### PR DESCRIPTION
Restyle `BudgetEntryRow` to align with `SummaryRow`'s visual style, making it less plain.

---
<a href="https://cursor.com/background-agent?bcId=bc-8e065cad-cb46-4d39-abbc-d8e619875264"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-8e065cad-cb46-4d39-abbc-d8e619875264"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

