### PR TITLE
refactor: return Loadable from DB hooks

### DIFF
--- a/src/app/hooks/useSectionState.ts
+++ b/src/app/hooks/useSectionState.ts
@@ -5,14 +5,18 @@ import { useItems } from "db/items";
 import { useCategories } from "db/categories";
 
 export function useSectionState(section: Section): Loadable<SectionState> {
-  const items = useItems(section);
-  const categories = useCategories(section);
+  const itemsLoadable = useItems(section);
+  const categoriesLoadable = useCategories(section);
 
-  const isLoading = !items || !categories;
-
-  if (isLoading) {
+  if (
+    itemsLoadable.status !== "ready" ||
+    categoriesLoadable.status !== "ready"
+  ) {
     return { status: "loading" };
   }
+
+  const items = itemsLoadable.data;
+  const categories = categoriesLoadable.data;
 
   const categorySummaries = categories.map((category) =>
     createCategorySummary(category, items),

--- a/src/db/categories.ts
+++ b/src/db/categories.ts
@@ -1,10 +1,16 @@
-import type { Category, Section } from "core/types";
+import type { Category, Loadable, Section } from "core/types";
 import { useLiveQuery } from "dexie-react-hooks";
 import { db } from "./db";
 import type { CategoryRecord, CategoriesTable, ItemsTable } from "./types";
 
-export function useCategories(section: Section): Category[] | undefined {
-  return useLiveQuery(() => getCategories(section), [section]);
+export function useCategories(section: Section): Loadable<Category[]> {
+  const data = useLiveQuery(() => getCategories(section), [section]);
+
+  if (data === undefined) {
+    return { status: "loading" };
+  }
+
+  return { status: "ready", data };
 }
 
 export async function getCategories(section: Section): Promise<Category[]> {

--- a/src/db/categories.ts
+++ b/src/db/categories.ts
@@ -4,13 +4,11 @@ import { db } from "./db";
 import type { CategoryRecord, CategoriesTable, ItemsTable } from "./types";
 
 export function useCategories(section: Section): Loadable<Category[]> {
-  const data = useLiveQuery(() => getCategories(section), [section]);
-
-  if (data === undefined) {
-    return { status: "loading" };
-  }
-
-  return { status: "ready", data };
+  return useLiveQuery(
+    async () => ({ status: "ready", data: await getCategories(section) }),
+    [section],
+    { status: "loading" }
+  );
 }
 
 export async function getCategories(section: Section): Promise<Category[]> {

--- a/src/db/items.ts
+++ b/src/db/items.ts
@@ -1,11 +1,17 @@
-import type { Item, Section } from "core/types";
+import type { Item, Loadable, Section } from "core/types";
 import { createItem } from "core/items";
 import { useLiveQuery } from "dexie-react-hooks";
 import { db } from "./db";
 import type { ItemRecord, ItemsTable } from "./types";
 
-export function useItems(section: Section): Item[] | undefined {
-  return useLiveQuery(() => getItems(section), [section]);
+export function useItems(section: Section): Loadable<Item[]> {
+  const data = useLiveQuery(() => getItems(section), [section]);
+
+  if (data === undefined) {
+    return { status: "loading" };
+  }
+
+  return { status: "ready", data };
 }
 
 export async function getItems(section: Section): Promise<Item[]> {

--- a/src/db/items.ts
+++ b/src/db/items.ts
@@ -5,13 +5,11 @@ import { db } from "./db";
 import type { ItemRecord, ItemsTable } from "./types";
 
 export function useItems(section: Section): Loadable<Item[]> {
-  const data = useLiveQuery(() => getItems(section), [section]);
-
-  if (data === undefined) {
-    return { status: "loading" };
-  }
-
-  return { status: "ready", data };
+  return useLiveQuery(
+    async () => ({ status: "ready", data: await getItems(section) }),
+    [section],
+    { status: "loading" }
+  );
 }
 
 export async function getItems(section: Section): Promise<Item[]> {


### PR DESCRIPTION
Move the Loadable pattern into useItems and useCategories hooks
so loading state is explicit at the data source.

https://claude.ai/code/session_019nCnjACoQqhbFq5xs3VKNg