### PR TITLE
Prevent body scroll in installed PWA on iOS refresh

### DIFF
--- a/src/base.css
+++ b/src/base.css
@@ -7,6 +7,12 @@
 }
 
 /* Body defaults */
+html,
+body {
+  height: 100%;
+  overflow: hidden;
+}
+
 body {
   margin: 0;
   line-height: 1.5;


### PR DESCRIPTION
## Summary

- Sets `overflow: hidden` on `html` and `body` to prevent document-level scrolling
- Fixes a quirk in iOS PWA standalone mode where refreshing causes a few pixels of body scroll due to `dvh` computing before safe area insets settle

## Test plan

- [ ] Install the app on iOS and refresh — verify no body scroll appears
- [ ] Verify scrollable areas within the app still scroll normally

https://claude.ai/code/session_014fvQVpwDFMSEVBemMeai7U

---
_Generated by [Claude Code](https://claude.ai/code/session_014fvQVpwDFMSEVBemMeai7U)_